### PR TITLE
Fixing problem with last version of gemoji

### DIFF
--- a/lib/velvet_rope.rb
+++ b/lib/velvet_rope.rb
@@ -41,7 +41,7 @@ module Redcarpet
       end
 
       def emoji_template(emoji)
-        %(<img alt="#{emoji.name}" src="images/emoji/#{emoji.image_filename}" style="vertical-align:middle" width="20" height="20" />)
+        %(<img alt="#{emoji.name}" src="/images/emoji/#{emoji.image_filename}" style="vertical-align:middle" width="20" height="20" />)
       end
 
     end

--- a/lib/velvet_rope.rb
+++ b/lib/velvet_rope.rb
@@ -30,8 +30,8 @@ module Redcarpet
       def postprocess(document)
         if @extensions[:emoji]
           document.gsub!(/:([a-z0-9\+\-_]+):/) do |match|
-            if Emoji.names.include?($1)
-              emoji_template($1)
+            if emoji = Emoji.find_by_alias($1)
+              emoji_template(emoji)
             else
               match
             end
@@ -40,8 +40,8 @@ module Redcarpet
         document
       end
 
-      def emoji_template(name)
-        '<img alt="' + name + '" src="' + "/images/emoji/#{name}.png" + '" style="vertical-align:middle" width="20" height="20" />'
+      def emoji_template(emoji)
+        %(<img alt="#{emoji.name}" src="images/emoji/#{emoji.image_filename}" style="vertical-align:middle" width="20" height="20" />)
       end
 
     end

--- a/spec/velvet_rope_spec.rb
+++ b/spec/velvet_rope_spec.rb
@@ -9,8 +9,8 @@ describe Redcarpet::Render::VelvetRope do
     it 'renders emoji characters' do
       content = 'This should be a :smiley: face.'
 
-      expected = '<p>This should be a <img alt="smiley" src="/images/emoji/smiley.png" style="vertical-align:middle" width="20" height="20" /> face.</p>' + "\n"
-      markdown.render(content).should eq(expected)
+      expected = '<p>This should be a <img alt="smiley" src="images/emoji/unicode/1f603.png" style="vertical-align:middle" width="20" height="20" /> face.</p>' + "\n"
+      expect(markdown.render(content)).to eq(expected)
     end
   end
 
@@ -26,8 +26,8 @@ This is an example of some Ruby code:
     end
       EOS
 
-      expected = %{<p>This is an example of some Ruby code:</p>\n<div class=\"highlight\"><pre><span class=\"n\">def</span> <span class=\"n\">my_method</span>\n  <span class=\"s\">&#39;my string&#39;</span><span class=\"p\">.</span><span class=\"n\">uppercase</span>\n<span class=\"k\">end</span>\n</pre></div>}
-      markdown.render(content).should eq(expected)
+      expected = %{<p>This is an example of some Ruby code:</p>\n<div class="highlight"><pre><span class="vg">def</span><span class="w"> </span><span class="vg">my_method</span>\n<span class="w">  </span><span class="c1">&#39;my string&#39;.uppercase</span>\n<span class="vg">end</span>\n</pre></div>}
+      expect(markdown.render(content)).to eq(expected)
     end
   end
 
@@ -46,7 +46,7 @@ end
       EOS
 
       expected = %{<p>This is an example of some Ruby code in a fenced code block:</p>\n<div class=\"highlight\"><pre><span class=\"k\">def</span> <span class=\"nf\">my_method</span>\n  <span class=\"s1\">&#39;my string&#39;</span><span class=\"o\">.</span><span class=\"n\">uppercase</span>\n<span class=\"k\">end</span>\n</pre></div>}
-      markdown.render(content).should eq(expected)
+      expect(markdown.render(content)).to eq(expected)
     end
 
     it "gracefully handles invalid lexers" do
@@ -58,8 +58,8 @@ end
 ```
       EOS
 
-      expected = %{<div class=\"highlight\"><pre><span class=\"n\">def</span> <span class=\"n\">my_method</span>\n  <span class=\"s\">&#39;my string&#39;</span><span class=\"p\">.</span><span class=\"n\">uppercase</span>\n<span class=\"k\">end</span>\n</pre></div>}
-      markdown.render(content).should eq(expected)
+      expected = %{<div class="highlight"><pre><span class="vg">def</span><span class="w"> </span><span class="vg">my_method</span>\n<span class="w">  </span><span class="c1">&#39;my string&#39;.uppercase</span>\n<span class="vg">end</span>\n</pre></div>}
+      expect(markdown.render(content)).to eq(expected)
     end
   end
 

--- a/velvet_rope.gemspec
+++ b/velvet_rope.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = "velvet_rope"
-  gem.version       = "0.0.3"
+  gem.version       = "0.0.4"
   gem.authors       = ["Sean Gaffney"]
   gem.email         = ["sean@seangaffney.cc"]
   gem.description   = %q{VelvetRope is a renderer to complement and enhance Redcarpet's default HTML renderer. It adds support for emoji and syntax-highlighting.}
@@ -16,9 +16,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency "rspec"
+  gem.add_development_dependency "rspec", '~> 3.0'
 
-  gem.add_runtime_dependency "redcarpet"
-  gem.add_runtime_dependency "pygments.rb"
-  gem.add_runtime_dependency "gemoji"
+  gem.add_runtime_dependency "redcarpet", "~> 3.0"
+  gem.add_runtime_dependency "pygments.rb", "~> 0.6"
+  gem.add_runtime_dependency "gemoji", "~> 2.0"
 end


### PR DESCRIPTION
# Description

This PR solves #1. It adds support for the last version of [gemoji](https://github.com/github/gemoji), and locks gem dependencies version in the `gemspec` to prevent further problems with gem versions.
## Tasks
- [x] Lock gem dependencies versions in `gemspec`
- [x] Update syntax to comply with the new gemoji version
- [x] Changing `should` to `expect` assertions format in rspec
- [x] Fixing tests to be green with new code changes
- [x] Patch version bump
